### PR TITLE
電卓の大枠づくり

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const server = http.createServer((req, res) => {
     try {
       const cssFile = fs.readFileSync('./resources/css/' + urlDirectories[2]);
       res.writeHead(200, {
-        'Content-Type': 'text/css charset=utf-8'
+        'Content-Type': 'text/css;charset=utf-8'
       });
       res.write(cssFile);
     } catch (e) {
@@ -26,7 +26,7 @@ const server = http.createServer((req, res) => {
     try {
       const jsFile = fs.readFileSync('./resources/js/' + urlDirectories[2]);
       res.writeHead(200, {
-        'Content-Type': 'text/javascript charset=utf-8'
+        'Content-Type': 'text/javascript;charset=utf-8'
       });
       res.write(jsFile);
     } catch (e) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,19 @@
 'use strict';
 const http = require('http');
+const pug = require('pug');
+const fs = require('fs');
+
 const server = http.createServer((req, res) => {
+  if (req.url === '/calculator') {
+    res.writeHead(200, {
+      'Content-Type': 'text/html; charset=utf-8'
+    });
+    res.write(pug.renderFile('./resources/calculator.pug'));
+    res.end();
+    return;
+  }
+
+  // デフォルトぺージ
   res.writeHead(200, {
     'Content-Type': 'text/html; charset=utf-8'
   });
@@ -10,7 +23,9 @@ const server = http.createServer((req, res) => {
         <h1>HTMLの一番大きい見出しを表示します</h1>
       </body>
     </html>`
-  ); res.end();
+  );
+  res.end();
+  return;
 });
 const port = 8000;
 server.listen(port, () => {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,42 @@ const pug = require('pug');
 const fs = require('fs');
 
 const server = http.createServer((req, res) => {
+  const urlDirectories = req.url.split('/');
+  // URLによってJSやCSSの振り分け
+  if (urlDirectories[1] === 'css') {
+    // ブラウザ用CSS読み込み
+    try {
+      const cssFile = fs.readFileSync('./resources/css/' + urlDirectories[2]);
+      res.writeHead(200, {
+        'Content-Type': 'text/css charset=utf-8'
+      });
+      res.write(cssFile);
+    } catch (e) {
+      //TODO client errorの追加
+      console.log(e);
+    } finally {
+      res.end();
+      return;
+    }
+  } else if (urlDirectories[1] === 'js') {
+    // ブラウザ用JS読み込み
+    try {
+      const jsFile = fs.readFileSync('./resources/js/' + urlDirectories[2]);
+      res.writeHead(200, {
+        'Content-Type': 'text/javascript charset=utf-8'
+      });
+      res.write(jsFile);
+    } catch (e) {
+      //TODO client errorの追加
+      console.error(e);
+    } finally {
+      res.end();
+      return;
+    }
+  }
+
+
+  // 以降、ページやリダイレクトの読み込み
   if (req.url === '/calculator') {
     res.writeHead(200, {
       'Content-Type': 'text/html; charset=utf-8'

--- a/resources/calculator.pug
+++ b/resources/calculator.pug
@@ -3,6 +3,64 @@ html(lang="ja")
   head
     meta(charset="UTF-8")
     title test
-    script(src="./js/calculator.js")
+    link(href="/css/calculator.css" rel="stylesheet" type="text/css")
+    script(src="/js/calculator.js")
   body
     div#test test-div
+    #calc_container
+      .calc_display
+        input#result(type="text" disabled)
+      .calc_row
+        .calc_button
+          button#calc-a a
+        .calc_button
+          button#calc-b b
+        .calc_button
+          button#calc-c c
+        .calc_button
+          button#calc-clear C
+      .calc_row
+        .calc_button
+          button#calc-d d
+        .calc_button
+          button#calc-e e
+        .calc_button
+          button#calc-f f
+        .calc_button
+          button#calc-divide /
+      .calc_row
+        .calc_button
+          button#calc-seven 7
+        .calc_button
+          button#calc-eight 8
+        .calc_button
+          button#calc-nine 9
+        .calc_button
+          button#calc-multiply *
+      .calc_row
+        .calc_button
+          button#calc-four 4
+        .calc_button
+          button#calc-five 5
+        .calc_button
+          button#calc-six 6
+        .calc_button
+          button#calc-minus -
+      .calc_row
+        .calc_button
+          button#calc-one 1
+        .calc_button
+          button#calc-two 2
+        .calc_button
+          button#calc-three 3
+        .calc_button
+          button#calc-plus +
+      .calc_row
+        .calc_button
+          button#calc-zero 0
+        .calc_button
+          button#calc-double-zero 00
+        .calc_button
+          button#calc-period .
+        .calc_button
+          button#calc-equal =

--- a/resources/calculator.pug
+++ b/resources/calculator.pug
@@ -3,5 +3,6 @@ html(lang="ja")
   head
     meta(charset="UTF-8")
     title test
+    script(src="./js/calculator.js")
   body
     div#test test-div

--- a/resources/calculator.pug
+++ b/resources/calculator.pug
@@ -1,0 +1,7 @@
+doctype html
+html(lang="ja")
+  head
+    meta(charset="UTF-8")
+    title test
+  body
+    div#test test-div

--- a/resources/css/calculator.css
+++ b/resources/css/calculator.css
@@ -1,0 +1,3 @@
+.calc_row {
+  display: flex;
+}

--- a/resources/css/calculator.css
+++ b/resources/css/calculator.css
@@ -1,3 +1,8 @@
 .calc_row {
   display: flex;
 }
+
+.calc_button > button {
+  width: 30px;
+  padding: 5px;
+}

--- a/resources/js/calculator.js
+++ b/resources/js/calculator.js
@@ -1,0 +1,6 @@
+'use strict';
+
+window.onload = () => {
+  const testDiv = document.getElementById('test');
+  testDiv.innerText += ' from calculator.js';
+};


### PR DESCRIPTION
## 実装/変更内容
- CSS/JSの読み込み用のURL振り分け
  - HTMLやブラウザ用JS内で `<script src="/js/javaScript.js"></script>` などとすると、
  ファイル `resources/js/javaScript.js` が読まれます
  - HTMLやブラウザ用JS内で `<link href="/css/cascadingStyleSheet.css" />` とすると、
  ファイル `resources/css/cascadingStyleSheet.css` が読まれます
- 電卓pugの大まかな作成
- 電卓pugの見た目用CSSの作成

## 実装/変更理由
- https://github.com/satsukizzz/n-playspace-http/discussions/22
- 電卓するためのブラウザ用JavaScript, CSSの読み込みができない状態であったため、index.jsへのURL振り分け機能を追加( 32fe682 )

## スクリーンショット/デザイン
こんな感じになりました。なってないかもしれないですが……
![image](https://user-images.githubusercontent.com/41767316/138707941-5b307ba9-c42c-414c-bf35-e4a128d558f0.png)

## 確認に必要なコマンド群
- `localhost:8000/calculator` へアクセスしてください

## その他
- 私の環境では4列ずつにするCSS( `display: flex;` )が当たりません。ロードがされているのに適用されないという謎のChromeのバグに阻まれてます。FirefoxではしっかりCSS当たってるのですが、なにかお気づきの方はコメントください。先生方にも確認してもらおうかと思ってます…。