### PR TITLE
Herokuでデプロイできるようにしました

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ ENV LANG ja_JP.UTF-8
 ENV TZ Asia/Tokyo
 RUN yarn add pug@2.0.4
 
+COPY . /app
 WORKDIR /app

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,5 @@
+build:
+  docker:
+    web: Dockerfile
+run:
+  web: yarn install && node index.js

--- a/heroku.yml
+++ b/heroku.yml
@@ -2,4 +2,4 @@ build:
   docker:
     web: Dockerfile
 run:
-  web: cd / && yarn install && node index.js
+  web: yarn install && node index.js

--- a/heroku.yml
+++ b/heroku.yml
@@ -2,4 +2,4 @@ build:
   docker:
     web: Dockerfile
 run:
-  web: yarn install && node index.js
+  web: cd / && yarn install && node index.js

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const server = http.createServer((req, res) => {
     </html>`
   ); res.end();
 });
-const port = 8000;
+const port = process.env.PORT || 8000;
 server.listen(port, () => {
   console.log('Listening on ' + port);
 });


### PR DESCRIPTION
## 実装/変更内容
- https://n-playspace-http.herokuapp.com/ に `main` ブランチを自動デプロイするようにHerokuの設定
- 私のHerokuAppとこのリポジトリの連携設定

コード面
- デプロイにあたり、コンテナへのコピーとポート指定の追加
- herokuでコンテナを扱う `heroku.yml` の設定 (https://devcenter.heroku.com/ja/articles/build-docker-images-heroku-yml)

## 実装/変更理由
- だって公開したいじゃん作ったものは！

## スクリーンショット/デザイン

## 確認に必要なコマンド群
- Herokuの動作確認
  - https://n-playspace-http.herokuapp.com/ へアクセス
  - ↑一時的に `heroku-deploy` ブランチをデプロイしてあります
- ローカルでの動作確認
  1. `docker-compose up --build -d`
  2. `docker-compose exec app node index.js` などのサーバー起動コマンド
  3. `localhost:8000` へアクセス

## その他
- 今後は、GitHub上の `main` ブランチが更新されるたびに上記herokuappのURLに**自動デプロイ**されます 🎉 🎉 